### PR TITLE
Fixed to support Whether links should open in a new window/tab

### DIFF
--- a/plugins/ViewBrowserPlugin/ArchiveCreator.php
+++ b/plugins/ViewBrowserPlugin/ArchiveCreator.php
@@ -63,7 +63,7 @@ class ArchiveCreator
                 $params['uid'] = $uid;
             }
             $url = publicUrl($params);
-            $link = new PageLink($url, $c['subject'], ['target' => '_blank']);
+            $link = new PageLink($url, $c['subject'], ['target' => getConfig('viewbrowser_target') ? '_blank' : '']);
 
             yield [
                 'id' => $c['messageid'],
@@ -181,7 +181,7 @@ class ArchiveCreator
                 $key = $row['id'];
                 $w->addElement($key);
                 $w->addColumn($key, s('Sent'), $row['entered']);
-                $w->addColumn($key, s('Campaign'), $row['subject'], $row['url'], '', ['target' => '_blank']);
+                $w->addColumn($key, s('Campaign'), $row['subject'], $row['url'], '', ['target' => getConfig('viewbrowser_target') ? '_blank' : '']);
             }
         };
         $totalCallback = function () use ($uid) {


### PR DESCRIPTION
The **Whether links should open in a new window/tab** admin option was being ignored

I've made a quick fix to use `target=''` in case the option is turned off (which is the default). It might be better to just not declare `target=` in the first place in this case though.

![image](https://github.com/bramley/phplist-plugin-viewbrowser/assets/1773306/cbf43441-5537-41ff-b20a-d26ec55a9f7e)
